### PR TITLE
Add CRI-O as a primary runtime option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -473,10 +473,11 @@ data "template_file" "milpa-worker-userdata" {
   template = file(var.milpa-worker-userdata)
 
   vars = {
-    k8stoken        = local.k8stoken
-    k8s_version     = var.k8s-version
-    masterIP        = aws_instance.k8s-master.private_ip
-    network_plugin  = var.network-plugin
+    k8stoken          = local.k8stoken
+    k8s_version       = var.k8s-version
+    masterIP          = aws_instance.k8s-master.private_ip
+    network_plugin    = var.network-plugin
+    container_runtime = var.container-runtime
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -170,3 +170,9 @@ variable "configure-cloud-routes" {
 variable "ecs-cluster-name" {
   default = ""
 }
+
+variable "container-runtime" {
+  // The primary (non-milpa) container runtime. It can either be "containerd"
+  // or "crio".
+  default = "containerd"
+}


### PR DESCRIPTION
I had this locally on my laptop since I tested CRI-O for Openshift support. I thought it made sense to add it as a container runtime option on workers.